### PR TITLE
A missing r in --stip-all

### DIFF
--- a/config/image-optimizer.php
+++ b/config/image-optimizer.php
@@ -8,7 +8,7 @@ use Spatie\ImageOptimizer\Optimizers\Jpegoptim;
 
 return [
     'optimizers' => [
-        Jpegoptim::class => ['--stip-all', '--all-progressive'],
+        Jpegoptim::class => ['--strip-all', '--all-progressive'],
         Pngquant::class => ['--force'],
         Optipng::class => ['-i0', '-o2', '-quiet'],
         Svgo::class => ['--disable=cleanupIDs'],


### PR DESCRIPTION
I believe there is a missing _r_ in the jpegoptim parameter '--strip-all'.