### PR TITLE
Enhanced readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Route::middleware('optimizeImages')->group(function () {
 
 ### Adding your own optimizers
 
-To learn how to create your own optimizer read [the "Writing custom optimizers" section](https://github.com/spatie/image-optimizer#writing-a-custom-optimizers) in the readme of the underlying [spatie/image-optimizer](https://github.com/spatie/image-optimizer#writing-a-custom-optimizers) package.
+To learn how to create your own optimizer read the ["Writing custom optimizers" section](https://github.com/spatie/image-optimizer#writing-a-custom-optimizers) in the readme of the underlying [spatie/image-optimizer](https://github.com/spatie/image-optimizer#writing-a-custom-optimizers) package.
 
 You can add the fully qualified classname of your optimizer as a key in the `optimizers` array in the config file.
 


### PR DESCRIPTION
A link had part of the body of the text which i think is not supposed to be there. Its better having 'the' out of the link.