### PR TITLE
Add missing config option so that jpegs actually get properly optimized

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ return [
     'optimizers' => [
 
         Jpegoptim::class => [
+            '-m85', // set maximum quality to 85%
             '--strip-all',  // this strips out all text information such as comments and EXIF data
             '--all-progressive'  // this will make sure the resulting image is a progressive one
         ],

--- a/config/image-optimizer.php
+++ b/config/image-optimizer.php
@@ -14,6 +14,7 @@ return [
     'optimizers' => [
 
         Jpegoptim::class => [
+            '-m85', // set maximum quality to 85%
             '--strip-all',  // this strips out all text information such as comments and EXIF data
             '--all-progressive',  // this will make sure the resulting image is a progressive one
         ],


### PR DESCRIPTION
The [`OptimizerChainFactory` in `spatie/image-optimizer`](https://github.com/spatie/image-optimizer/blob/master/src/OptimizerChainFactory.php) has the `-m85` option for JpegOptim, whereas the config for the Laravel package is missing it. Therefore when using this package, jpegs are barely being optimized. This pull adds the missing option into the config, restoring parity between the two packages.