### PR TITLE
Optimize just valid (uploaded without errors) files

### DIFF
--- a/src/Middlewares/OptimizeImages.php
+++ b/src/Middlewares/OptimizeImages.php
@@ -15,7 +15,9 @@ class OptimizeImages
         collect($request->allFiles())
             ->flatten()
             ->each(function (UploadedFile $file) use ($optimizerChain) {
-                $optimizerChain->optimize($file->getPathname());
+                if ($file->isValid()) {
+                    $optimizerChain->optimize($file->getPathname());
+                }
             });
 
         return $next($request);

--- a/src/Middlewares/OptimizeImages.php
+++ b/src/Middlewares/OptimizeImages.php
@@ -14,10 +14,11 @@ class OptimizeImages
 
         collect($request->allFiles())
             ->flatten()
+            ->filter(function (UploadedFile $file) {
+                return $file->isValid();
+            })
             ->each(function (UploadedFile $file) use ($optimizerChain) {
-                if ($file->isValid()) {
-                    $optimizerChain->optimize($file->getPathname());
-                }
+                $optimizerChain->optimize($file->getPathname());
             });
 
         return $next($request);

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -65,7 +65,9 @@ class MiddlewareTest extends TestCase
             $path,
             pathinfo($path, PATHINFO_BASENAME),
             mime_content_type($path),
-            filesize($path)
+            filesize($path),
+            null,
+            true
         );
     }
 }


### PR DESCRIPTION
When an image wasn't uploaded successfully (usually due to upload_max_filesize, post_max_size or other configuration) middleware attempt to optimize a path of an unexisting image then throw an `InvalidArgumentException` with unhelpful message `'' does not exist` preventing other middleware to handle the request such a `ValidatePostSize`, and even FormRequest validation. the solution is simple since the `$file` being handled is an instance of Symfony `UploadedFile` we can use `isValid()` method.

This PR fix #67 