### PR TITLE
Move orchestra testbench to dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
     "require": {
         "php": "^7.2",
         "laravel/framework": "^6.0|^7.0",
-        "orchestra/testbench": "^4.0|^5.0",
         "spatie/image-optimizer": "^1.2.0"
     },
     "require-dev": {
+        "orchestra/testbench": "^4.0|^5.0",
         "phpunit/phpunit": "^8.0"
     },
     "autoload": {


### PR DESCRIPTION
I noticed this while rolling out a release for our Laravel app recently updated to version 7. The server PHP version is 7.2.28 and this prevented us to deploy the changes