### PR TITLE
Bugfix for custom logger

### DIFF
--- a/src/OptimizerChainFactory.php
+++ b/src/OptimizerChainFactory.php
@@ -30,7 +30,7 @@ class OptimizerChainFactory
             return new DummyLogger();
         }
 
-        if (! $configuredLogger instanceof LoggerInterface) {
+        if (! is_a($configuredLogger, LoggerInterface::class, true)) {
             throw InvalidConfiguration::notAnLogger($configuredLogger);
         }
 


### PR DESCRIPTION
Customer logger using laravel config [setting `log_optimizer_activity' => MyCustomLogger` ] throws an exception (Logger is not a suitable logger). Reason being a wrong type check.

