### PR TITLE
Automatically wrap optimize call in Storage::disk()->path()

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,15 @@ ImageOptimizer::optimize($pathToImage);
 ImageOptimizer::optimize($pathToImage, $pathToOptimizedImage);
 ```
 
+#### Set Storage disk
+
+```php
+use ImageOptimizer;
+
+// the image will be replaced with an optimized version which should be smaller
+ImageOptimizer::disk('photos')->optimize($pathToImageFromPhotoDisk);
+```
+
 You don't like facades you say? No problem! Just resolve a configured instance of `Spatie\ImageOptimizer\OptimizerChain` out of the container:
 
 ```php

--- a/src/Facades/ImageOptimizer.php
+++ b/src/Facades/ImageOptimizer.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Storage;
 
 class ImageOptimizer extends Facade
 {
-    private static string $storageDisk = "local";
+    private static $storageDisk = "local";
 
     protected static function getFacadeAccessor()
     {

--- a/src/Facades/ImageOptimizer.php
+++ b/src/Facades/ImageOptimizer.php
@@ -3,11 +3,40 @@
 namespace Spatie\LaravelImageOptimizer\Facades;
 
 use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\Storage;
 
 class ImageOptimizer extends Facade
 {
+    private static string $storageDisk = "local";
+
     protected static function getFacadeAccessor()
     {
         return 'image-optimizer';
+    }
+
+    public static function optimize(string $pathToImage, string $pathToOutput = null)
+    {
+        if (file_exists($pathToImage)) {
+            parent::optimize($pathToImage, $pathToOutput);
+
+            return;
+        }
+        if (file_exists(Storage::disk(self::$storageDisk)->path($pathToImage))) {
+            if ($pathToOutput !== null) {
+                $pathToOutput = Storage::disk(self::$storageDisk)->path($pathToOutput);
+            }
+            parent::optimize(Storage::disk(self::$storageDisk)->path($pathToImage), $pathToOutput);
+
+            return;
+        }
+
+        throw new InvalidArgumentException("`{$pathToImage}` does not exist");
+    }
+
+    public static function disk(string $disk)
+    {
+        self::$storageDisk = $disk;
+
+        return new static;
     }
 }

--- a/tests/FacadeTest.php
+++ b/tests/FacadeTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\LaravelImageOptimizer\Test;
 
+use Illuminate\Support\Facades\Storage;
 use ImageOptimizer;
 
 class FacadeTest extends TestCase
@@ -16,5 +17,20 @@ class FacadeTest extends TestCase
         ImageOptimizer::optimize($testImagePath, $destinationPath);
 
         $this->assertDecreasedFileSize($destinationPath, $testImagePath);
+    }
+
+    /** @test */
+    public function it_can_wrap_a_path_to_image_in_storage_facade_path()
+    {
+        Storage::fake('photos');
+
+        $path = str_replace(__DIR__, "", $this->getImagePath('logo.png'));
+
+        Storage::disk('photos')->put($path, file_get_contents($this->getImagePath('logo.png')));
+
+        ImageOptimizer::disk('photos')
+            ->optimize($path);
+
+        $this->assertDecreasedFileSize(Storage::disk('photos')->path($path), $this->getImagePath('logo.png'));
     }
 }


### PR DESCRIPTION
Resolves #95 

If the given `$pathToImage` for the call to `optimize` does not exist, this PR will try using `Storage::disk($disk)->path($pathToImage)`. 

In case the user wants to use a different disk, this PR also extended the API and added a `disk` method on the facade.

This way you can have code like this in a controller without needing to manually wrap the `$pathToImage` returned by the `storeAs` method in laravel.
```php
use ImageOptimizer;
use Illuminate\Http\Request;
//...
function store(Request $request)
{
  $file = $request->file('image');

  $filename = $file->getClientOriginalName();
  $pathToImage = $file->storeAs('public/images/', $filename);
  ImageOptimizer::optimize($pathToImage);
}
```